### PR TITLE
Remove unnecessary _.bind call that seems to contribute to memory/garbage

### DIFF
--- a/src/subscriptionDefinition.js
+++ b/src/subscriptionDefinition.js
@@ -61,15 +61,13 @@ SubscriptionDefinition.prototype = {
 		if ( !_.isNumber( maxCalls ) || maxCalls <= 0 ) {
 			throw new Error( "The value provided to disposeAfter (maxCalls) must be a number greater than zero." );
 		}
-		var self = this;
-		var dispose = _.after( maxCalls, _.bind( function() {
-			self.unsubscribe();
-		} ) );
-		self.pipeline.push( function( data, env, next ) {
+
+		var dispose = _.after( maxCalls, this.unsubscribe.bind( this ) );
+		this.pipeline.push( function( data, env, next ) {
 			next( data, env );
 			dispose();
 		} );
-		return self;
+		return this;
 	},
 
 	distinct: function distinct() {


### PR DESCRIPTION
In analyzing memory usage in rabbot publishing, we found that the `_.bind` call (which has a lot of complexity inside recent versions of lodash), was contributing significantly to Node memory consumption (not as a leak, but as data in the old section of the heap that is described as not being reclaimed until there is memory pressure).